### PR TITLE
update elastic version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/doug-martin/goqu/v9 v9.18.0
-	github.com/elastic/go-elasticsearch/v8 v8.0.0-20211214143643-cd88bcfe6133
+	github.com/elastic/go-elasticsearch/v7 v7.13.1
 	github.com/gofrs/uuid v4.2.0+incompatible // indirect
 	github.com/golang/mock v1.6.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -115,10 +115,8 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/denisenkom/go-mssqldb v0.10.0/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
 github.com/doug-martin/goqu/v9 v9.18.0 h1:/6bcuEtAe6nsSMVK/M+fOiXUNfyFF3yYtE07DBPFMYY=
 github.com/doug-martin/goqu/v9 v9.18.0/go.mod h1:nf0Wc2/hV3gYK9LiyqIrzBEVGlI8qW3GuDCEobC4wBQ=
-github.com/elastic/elastic-transport-go/v8 v8.0.0-20211202110751-50105067ef27 h1:O58SwZ7pdt7Lzy8JqpJubJlgDbr9jVV7ro4HFPvaZDw=
-github.com/elastic/elastic-transport-go/v8 v8.0.0-20211202110751-50105067ef27/go.mod h1:87Tcz8IVNe6rVSLdBux1o/PEItLtyabHU3naC7IoqKI=
-github.com/elastic/go-elasticsearch/v8 v8.0.0-20211214143643-cd88bcfe6133 h1:dXJSi+Yt91M26nm0uEKYg+H1mUajDc0gAkfMMjFQGCA=
-github.com/elastic/go-elasticsearch/v8 v8.0.0-20211214143643-cd88bcfe6133/go.mod h1:n4xUBsMfOgfj0rCtMLBCxEzsucYlx1pknAqWxI2D9o0=
+github.com/elastic/go-elasticsearch/v7 v7.13.1 h1:PaM3V69wPlnwR+ne50rSKKn0RNDYnnOFQcuGEI0ce80=
+github.com/elastic/go-elasticsearch/v7 v7.13.1/go.mod h1:OJ4wdbtDNk5g503kvlHLyErCgQwwzmDtaFC4XyOxXA4=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/internal/pkg/provider/metadata/elastic_provider.go
+++ b/internal/pkg/provider/metadata/elastic_provider.go
@@ -21,12 +21,12 @@ import (
 	"crypto/md5"
 	"encoding/json"
 	"fmt"
+	"github.com/elastic/go-elasticsearch/v7"
 	"strings"
 	"sync"
 	"time"
 
-	"github.com/elastic/go-elasticsearch/v8"
-	"github.com/elastic/go-elasticsearch/v8/esapi"
+	"github.com/elastic/go-elasticsearch/v7/esapi"
 
 	"github.com/napptive/catalog-manager/internal/pkg/entities"
 	"github.com/napptive/catalog-manager/internal/pkg/utils"


### PR DESCRIPTION
### Checklist
- [ ] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README/documentation, if necessary

#### What does this PR do?
Fix elastic lib to v7

#### Where should the reviewer start?

#### What is missing?

#### How should this be manually tested?

#### Any background context you want to provide?
in the last lib update, the `elastic/go-elasticsearch` lib was updated and the new version was incompatible with the elastic deployed in the cluster.
```
[Unknown] the client noticed that the server is not Elasticsearch and we do not support this unknown product","time":"2021-12-16T15:19:39Z","message":"error creating providers
```

#### What are the associated tickets?

[PG-XX](https://napptive.atlassian.net/browse/PG-XX)

#### Screenshots (if appropriate)

#### Questions
