### PR TITLE
fix a bug when operating in account namespace

### DIFF
--- a/internal/pkg/server/catalog-manager/handler.go
+++ b/internal/pkg/server/catalog-manager/handler.go
@@ -203,7 +203,14 @@ func (h *Handler) validateUser(ctx context.Context, appName string, action strin
 		if appID.Namespace != claim.Username {
 
 			// Check target account
-			if appID.Namespace == claim.AccountName && requireAdminPriviledge == claim.AccountAdmin {
+			if appID.Namespace == claim.AccountName {
+				if requireAdminPriviledge {
+					if claim.AccountAdmin {
+						return nil
+					} else {
+						return nerrors.NewPermissionDeniedError("%s operation requires ADMIN privileges", action)
+					}
+				}
 				return nil
 			}
 


### PR DESCRIPTION
### Checklist
- [ ] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README/documentation, if necessary

#### What does this PR do?
Fix a bug when operating in the account namespace. 
The users can operate in their account namespace. When 'requireAdminPriviledge' only admin users can do it

#### Where should the reviewer start?

#### What is missing?

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the associated tickets?

[PG-XX](https://napptive.atlassian.net/browse/PG-XX)

#### Screenshots (if appropriate)

#### Questions
